### PR TITLE
Fix typo in documentation header

### DIFF
--- a/mod_sftp_ldap.html
+++ b/mod_sftp_ldap.html
@@ -7,7 +7,7 @@
 
 <hr>
 <center>
-<h2><b>ProFTPD module <code>mod_sftp_sql</code></b></h2>
+<h2><b>ProFTPD module <code>mod_sftp_ldap</code></b></h2>
 </center>
 <hr><br>
 


### PR DESCRIPTION
Change `mod_sftp_sql` to `mod_sftp_ldap` in heading.